### PR TITLE
Create dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # This points to .github/workflows
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Renamed .github/dependabots.yaml to .github/dependabot.yml to follow the required GitHub naming convention. This ensures Dependabot can detect and apply security and version updates correctly.

https://github.com/qualcomm/qualcomm-repository-template/blob/main/.github/dependabot.yaml