### PR TITLE
ci: add build environment diagnostics for troubleshooting

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,6 +5,14 @@
 
 set -euxo pipefail
 
+# CI diagnostic - verify runner environment
+echo "=== RUNNER DIAGNOSTIC ==="
+date
+hostname
+whoami
+id
+echo "=== END DIAGNOSTIC ==="
+
 echo "Running SensingHub build script..."
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Add diagnostic logging to ci/build.sh to help troubleshoot build failures on the CI runner.\n\nThis PR adds `date`, `hostname`, `whoami`, and `id` output at the start of the build script to verify the runner environment and aid in debugging.