### PR TITLE
Replace pull_request_target with pull_request in GitHub Actions workflow

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -3,7 +3,7 @@ name: pre_merge_build
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main


### PR DESCRIPTION
This PR replaces 'pull_request_target' with 'pull_request' in the GitHub Actions workflow.