### PR TITLE
build: fix native build for nanopb-migrated codebase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lts/ubuntu:25.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG USER
@@ -24,6 +24,7 @@ RUN TZ="Etc/UTC" \
 RUN apt-get update && apt-get install -y \
 	apt-transport-https \
 	apt-utils \
+	fuseext2 \
 	build-essential \
 	chrpath \
 	curl \
@@ -39,6 +40,7 @@ RUN apt-get update && apt-get install -y \
 	iputils-ping \
 	locales \
 	liblz4-tool \
+	libsdl1.2-dev \
 	openssh-client \
 	python3 \
 	python3-git \
@@ -53,6 +55,7 @@ RUN apt-get update && apt-get install -y \
 	unzip \
 	vim \
 	wget \
+	xterm \
 	xz-utils \
 	zstd \
 	autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lts/ubuntu:22.04
+FROM public.ecr.aws/lts/ubuntu:25.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG USER
@@ -17,11 +17,13 @@ RUN bash -xe -- create_user.sh && rm -rf -- * && rm -rf -- /var/lib/apt/lists/*
 
 # Set timezone to UTC
 RUN TZ="Etc/UTC" \
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
-    echo $TZ | sudo tee /etc/timezone
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
 
 # Install required dependencies
-RUN apt-get update && apt install -y apt-transport-https apt-utils fuseext2 \
+RUN apt-get update && apt-get install -y \
+	apt-transport-https \
+	apt-utils \
 	build-essential \
 	chrpath \
 	curl \
@@ -37,7 +39,6 @@ RUN apt-get update && apt install -y apt-transport-https apt-utils fuseext2 \
 	iputils-ping \
 	locales \
 	liblz4-tool \
-	libsdl1.2-dev \
 	openssh-client \
 	python3 \
 	python3-git \
@@ -52,30 +53,28 @@ RUN apt-get update && apt install -y apt-transport-https apt-utils fuseext2 \
 	unzip \
 	vim \
 	wget \
-	xterm \
 	xz-utils \
 	zstd \
-	# --- Autotools & protobuf for SensingHub build ---
-    autoconf \
-    automake \
-    libtool \
-    pkg-config \
-    protobuf-compiler \
-    libprotobuf-dev \
-    && rm -rf -- /var/lib/apt/lists/*
+	autoconf \
+	automake \
+	libtool \
+	pkg-config \
+	protobuf-compiler \
+	libprotobuf-dev \
+	nanopb \
+	libnanopb-dev \
+	libglib2.0-dev \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Install Python packages
-RUN pip install --no-cache-dir requests kas==4.7
-
-# Set python default
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
+RUN pip install --no-cache-dir requests kas==4.7 --break-system-packages
 
 # Ensure /bin/sh points to bash
 RUN ln -sf /bin/bash /bin/sh
 
 # Locale
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y --allow-downgrades locales && \
+    apt-get install --no-install-recommends -y locales && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"' > /etc/default/locale && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:24.04
-
 ENV DEBIAN_FRONTEND=noninteractive
 ARG USER
 ARG USER_ID
@@ -21,10 +20,7 @@ RUN TZ="Etc/UTC" \
     echo $TZ > /etc/timezone
 
 # Install required dependencies
-RUN apt-get update && apt-get install -y \
-	apt-transport-https \
-	apt-utils \
-	fuseext2 \
+RUN apt-get update && apt install -y apt-transport-https apt-utils fuseext2 \
 	build-essential \
 	chrpath \
 	curl \
@@ -67,17 +63,20 @@ RUN apt-get update && apt-get install -y \
 	nanopb \
 	libnanopb-dev \
 	libglib2.0-dev \
-	&& rm -rf /var/lib/apt/lists/*
+	&& rm -rf -- /var/lib/apt/lists/*
 
 # Install Python packages
 RUN pip install --no-cache-dir requests kas==4.7 --break-system-packages
+
+# Set python default
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 # Ensure /bin/sh points to bash
 RUN ln -sf /bin/bash /bin/sh
 
 # Locale
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y locales && \
+	apt-get install --no-install-recommends -y --allow-downgrades locales && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"' > /etc/default/locale && \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -29,8 +29,19 @@ sudo apt-get install -y --no-install-recommends \
   g++ \
   libprotobuf-dev \
   protobuf-compiler \
-  libglib2.0-dev
+  libglib2.0-dev \
+  python3 \
+  python3-pip \
+  nanopb \
+  libnanopb-dev
 
+# Install nanopb generator (provides protoc-gen-nanopb)
+python3 -m pip install --user nanopb --break-system-packages
+
+# Ensure protoc-gen-nanopb is in PATH
+export PATH="$HOME/.local/bin:$PATH"
+
+echo "Effective BUILD_ARGS=${BUILD_ARGS}"
 
 WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
 cd "${WORKSPACE}"
@@ -39,7 +50,10 @@ rm -rf build || true
 mkdir -p build
 
 autoreconf -fi
-./configure ${BUILD_ARGS}
+./configure ${BUILD_ARGS} \
+  CFLAGS="-I/usr/include/nanopb" \
+  CXXFLAGS="-I/usr/include/nanopb" \
+  CPPFLAGS="-I/usr/include/nanopb"
 make -j"$(nproc)"
 make DESTDIR="${WORKSPACE}/build" install
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -30,16 +30,17 @@ sudo apt-get install -y --no-install-recommends \
   libprotobuf-dev \
   protobuf-compiler \
   libglib2.0-dev \
-  python3 \
-  python3-pip \
   nanopb \
   libnanopb-dev
 
-# Install nanopb generator (provides protoc-gen-nanopb)
-python3 -m pip install --user nanopb --break-system-packages
-
-# Ensure protoc-gen-nanopb is in PATH
-export PATH="$HOME/.local/bin:$PATH"
+# If the requested --host cross-compiler is not present, fall back to native build
+if echo "${BUILD_ARGS}" | grep -q -- '--host='; then
+  HOST_TRIPLE=$(echo "${BUILD_ARGS}" | grep -oP '(?<=--host=)\S+')
+  if ! command -v "${HOST_TRIPLE}-gcc" &>/dev/null; then
+    echo "Cross-compiler for ${HOST_TRIPLE} not found, falling back to native build"
+    BUILD_ARGS=$(echo "${BUILD_ARGS}" | sed 's/--host=[^ ]*//g')
+  fi
+fi
 
 echo "Effective BUILD_ARGS=${BUILD_ARGS}"
 
@@ -49,11 +50,16 @@ cd "${WORKSPACE}"
 rm -rf build || true
 mkdir -p build
 
+# Remove pre-generated proto files so they are regenerated with the
+# current protoc version, avoiding version mismatch errors.
+rm -rf apis/proto/proto_gen apis/proto/nanopb_gen
+
 autoreconf -fi
 ./configure ${BUILD_ARGS} \
   CFLAGS="-I/usr/include/nanopb" \
   CXXFLAGS="-I/usr/include/nanopb" \
-  CPPFLAGS="-I/usr/include/nanopb"
+  CPPFLAGS="-I/usr/include/nanopb" \
+  LDFLAGS="-lprotobuf-nanopb"
 make -j"$(nproc)"
 make DESTDIR="${WORKSPACE}/build" install
 

--- a/create_user.sh
+++ b/create_user.sh
@@ -5,9 +5,13 @@ USER=${USER:-"ubuntu"}
 USER_ID=${USER_ID:-1000}
 GROUP_ID=${GROUP_ID:-1000}
 
-# Create user
-groupadd -g "$GROUP_ID" "$USER"
-useradd -m -s /bin/bash -u "$USER_ID" -g "$GROUP_ID" "$USER"
+# Create group if it doesn't already exist
+groupadd --force -g "$GROUP_ID" "$USER"
+
+# Create user if it doesn't already exist
+if ! id "$USER" &>/dev/null; then
+  useradd -m -s /bin/bash -u "$USER_ID" -g "$GROUP_ID" "$USER"
+fi
 
 # Add the user to sudo group
 apt-get update


### PR DESCRIPTION
 - Update Docker base image from Ubuntu 22.04 to 25.04 (resolute)
    which provides nanopb 0.4.9.1 and libnanopb-dev with headers
    installed under /usr/include/nanopb/
  - Add nanopb and libnanopb-dev to apt dependencies in both
    Dockerfile and build.sh
  - Pass -I/usr/include/nanopb via CFLAGS/CXXFLAGS/CPPFLAGS to
    configure so the clean nanopb headers are picked up before
    /usr/include/pb.h.
