### PR TITLE
sensors: load versioned QshSession library

### DIFF
--- a/session/1.0/src/SessionFactory.cpp
+++ b/session/1.0/src/SessionFactory.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 using namespace com::quic::sensinghub::session::V1_0 ;
 #ifdef SNS_VERSIONED_LIB_ENABLED
-#define SENSING_HUB_INTERFACE_LIB_NAME "libQshSession.so.1"
+#define SENSING_HUB_INTERFACE_LIB_NAME "libQshSession.so.2"
 #else
 #define SENSING_HUB_INTERFACE_LIB_NAME "libQshSession.so"
 #endif


### PR DESCRIPTION
Update the versioned library name to load `libQshSession.so.2` when `SNS_VERSIONED_LIB_ENABLED` is enabled.